### PR TITLE
fix: replace mapbox-gl-draw with custom polygon drawing (OPE-6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "open-sample",
       "version": "0.0.0",
       "dependencies": {
-        "@mapbox/mapbox-gl-draw": "^1.5.1",
         "@tmcw/togeojson": "^7.1.2",
         "@turf/turf": "^7.3.4",
         "maplibre-gl": "^5.21.0",
@@ -23,7 +22,6 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tailwindcss/vite": "^4.2.2",
-        "@types/mapbox__mapbox-gl-draw": "^1.4.9",
         "@types/node": "^24.12.0",
         "@types/pako": "^2.0.4",
         "@types/react": "^19.2.14",
@@ -572,24 +570,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mapbox/geojson-area": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
-      "integrity": "sha512-bBqqFn1kIbLBfn7Yq1PzzwVkPYQr9lVUeT8Dhd0NL5n76PBuXzOcuLV7GOSbEB1ia8qWxH4COCvFpziEu/yReA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "wgs84": "0.0.0"
-      }
-    },
-    "node_modules/@mapbox/geojson-normalize": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-normalize/-/geojson-normalize-0.0.1.tgz",
-      "integrity": "sha512-82V7YHcle8lhgIGqEWwtXYN5cy0QM/OHq3ypGhQTbvHR57DF0vMHMjjVSQKFfVXBe/yWCBZTyOuzvK7DFFnx5Q==",
-      "license": "ISC",
-      "bin": {
-        "geojson-normalize": "geojson-normalize"
-      }
-    },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -598,47 +578,13 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/@mapbox/mapbox-gl-draw": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.5.1.tgz",
-      "integrity": "sha512-DnR/oarZVoIrVHssAn+mtpuGzYH+ebORoPjow46zTBNPod/HQnvIZGtL6hIb5BVWxxH49RC9D20ipxiO9WDRxA==",
-      "license": "ISC",
-      "dependencies": {
-        "@mapbox/geojson-area": "^0.2.2",
-        "@mapbox/geojson-normalize": "^0.0.1",
-        "@mapbox/point-geometry": "^1.1.0",
-        "@turf/projection": "^7.2.0",
-        "fast-deep-equal": "^3.1.3",
-        "nanoid": "^5.0.9"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-draw/node_modules/nanoid": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
-      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
     "node_modules/@mapbox/mapbox-gl-supported": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
       "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "1.1.0",
@@ -3388,8 +3334,9 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
       "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -3422,17 +3369,6 @@
       "integrity": "sha512-tdJz7jaWFu4nR+8b2B+CdPZ6811ighYylWsu2hpsivapzW058yP0KdfZuNY89IiRe5jbKvBGXN3LQdN2KPXVdQ==",
       "license": "MIT"
     },
-    "node_modules/@types/mapbox__mapbox-gl-draw": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__mapbox-gl-draw/-/mapbox__mapbox-gl-draw-1.4.9.tgz",
-      "integrity": "sha512-8OtRdlSFbF/NDKg3CYQZPbI41JUwRPHIOB1f3fc3AG0Wb7CecSuuUG5EG+IsCmTHyzF6cyKpcjR/jcv62U3w6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*",
-        "mapbox-gl": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
@@ -3454,8 +3390,9 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -4101,8 +4038,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
       "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -4188,8 +4126,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4651,8 +4590,9 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/geokdbush": {
       "version": "2.0.1",
@@ -4715,8 +4655,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5272,8 +5213,9 @@
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.20.0.tgz",
       "integrity": "sha512-+rVQkf6ymUlAEJiQBZy0OiamJvQN4Uk15mRHI98PRUSmRS40GOoLJyEZEG39LEUtvmzc7qGh+4ygZfJ//O5VnQ==",
-      "devOptional": true,
       "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "peer": true,
       "workspaces": [
         "src/style-spec",
         "test/build/vite",
@@ -5311,15 +5253,17 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mapbox-gl/node_modules/tinyqueue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/maplibre-gl": {
       "version": "5.21.0",
@@ -5371,8 +5315,9 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.8.1.tgz",
       "integrity": "sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "robust-predicates": "^2.0.4",
         "splaytree": "^0.1.4",
@@ -5383,8 +5328,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -5964,8 +5910,9 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
       "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/splaytree-ts": {
       "version": "1.0.2",
@@ -6349,12 +6296,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/wgs84": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
-      "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@mapbox/mapbox-gl-draw": "^1.5.1",
     "@tmcw/togeojson": "^7.1.2",
     "@turf/turf": "^7.3.4",
     "maplibre-gl": "^5.21.0",
@@ -25,7 +24,6 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.2.2",
-    "@types/mapbox__mapbox-gl-draw": "^1.4.9",
     "@types/node": "^24.12.0",
     "@types/pako": "^2.0.4",
     "@types/react": "^19.2.14",

--- a/src/components/planning/PlanMap.tsx
+++ b/src/components/planning/PlanMap.tsx
@@ -1,53 +1,41 @@
-import { useRef, useCallback, useEffect } from 'react';
-import Map, { Source, Layer, type MapRef } from 'react-map-gl/maplibre';
-import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import { useCallback } from 'react';
+import Map, { Source, Layer } from 'react-map-gl/maplibre';
+import type { MapLayerMouseEvent } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 import { usePlanStore } from '../../stores/planStore';
+import { usePolygonDraw } from '../../hooks/usePolygonDraw';
 
 export default function PlanMap() {
-  const mapRef = useRef<MapRef>(null);
-  const drawRef = useRef<MapboxDraw | null>(null);
-  const { polygon, points, setPolygon } = usePlanStore();
+  const points = usePlanStore((s) => s.points);
+  const {
+    isDrawing,
+    vertices,
+    polygon,
+    startDrawing,
+    handleClick,
+    finishDrawing,
+    clearDrawing,
+    verticesGeoJson,
+    lineGeoJson,
+    previewPolygonGeoJson,
+    polygonGeoJson,
+  } = usePolygonDraw();
 
-  const onMapLoad = useCallback(() => {
-    const map = mapRef.current?.getMap();
-    if (!map) return;
+  const onClick = useCallback(
+    (e: MapLayerMouseEvent) => {
+      handleClick(e.lngLat);
+    },
+    [handleClick]
+  );
 
-    const draw = new MapboxDraw({
-      displayControlsDefault: false,
-      controls: { polygon: true, trash: true },
-    });
-    drawRef.current = draw;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    map.addControl(draw as any);
-
-    const updatePolygon = () => {
-      const data = draw.getAll();
-      if (data.features.length > 0) {
-        const feat = data.features[data.features.length - 1];
-        if (feat.geometry.type === 'Polygon') {
-          setPolygon(feat as GeoJSON.Feature<GeoJSON.Polygon>);
-        }
-      } else {
-        setPolygon(null);
-      }
-    };
-
-    map.on('draw.create', updatePolygon);
-    map.on('draw.update', updatePolygon);
-    map.on('draw.delete', updatePolygon);
-  }, [setPolygon]);
-
-  // If polygon is set externally (e.g. KML upload), add it to draw
-  useEffect(() => {
-    if (drawRef.current && polygon) {
-      const existing = drawRef.current.getAll();
-      if (existing.features.length === 0) {
-        drawRef.current.add(polygon);
-      }
-    }
-  }, [polygon]);
+  const onDblClick = useCallback(
+    (e: MapLayerMouseEvent) => {
+      if (!isDrawing) return;
+      e.preventDefault();
+      finishDrawing();
+    },
+    [isDrawing, finishDrawing]
+  );
 
   const pointsGeoJson: GeoJSON.FeatureCollection = {
     type: 'FeatureCollection',
@@ -59,35 +47,122 @@ export default function PlanMap() {
   };
 
   return (
-    <Map
-      ref={mapRef}
-      initialViewState={{ longitude: -98.5, latitude: 39.8, zoom: 4 }}
-      style={{ width: '100%', height: '100%' }}
-      mapStyle="https://tiles.openfreemap.org/styles/liberty"
-      onLoad={onMapLoad}
-    >
-      <Source id="sample-points" type="geojson" data={pointsGeoJson}>
-        <Layer
-          id="sample-points-circle"
-          type="circle"
-          paint={{
-            'circle-radius': 6,
-            'circle-color': '#e63946',
-            'circle-stroke-width': 2,
-            'circle-stroke-color': '#ffffff',
-          }}
-        />
-        <Layer
-          id="sample-points-label"
-          type="symbol"
-          layout={{
-            'text-field': ['get', 'index'],
-            'text-size': 11,
-            'text-offset': [0, -1.5],
-          }}
-          paint={{ 'text-color': '#1d3557' }}
-        />
-      </Source>
-    </Map>
+    <div className="relative w-full h-full">
+      <Map
+        initialViewState={{ longitude: -98.5, latitude: 39.8, zoom: 4 }}
+        style={{ width: '100%', height: '100%' }}
+        mapStyle="https://tiles.openfreemap.org/styles/liberty"
+        cursor={isDrawing ? 'crosshair' : undefined}
+        onClick={onClick}
+        onDblClick={onDblClick}
+      >
+        {/* Finalized polygon (drawn or KML-uploaded) */}
+        <Source id="polygon-fill" type="geojson" data={polygonGeoJson}>
+          <Layer
+            id="polygon-fill-layer"
+            type="fill"
+            paint={{ 'fill-color': '#3b82f6', 'fill-opacity': 0.15 }}
+          />
+          <Layer
+            id="polygon-outline-layer"
+            type="line"
+            paint={{ 'line-color': '#3b82f6', 'line-width': 2 }}
+          />
+        </Source>
+
+        {/* Drawing preview: polygon fill */}
+        <Source id="draw-preview" type="geojson" data={previewPolygonGeoJson}>
+          <Layer
+            id="draw-preview-fill"
+            type="fill"
+            paint={{ 'fill-color': '#3b82f6', 'fill-opacity': 0.1 }}
+          />
+        </Source>
+
+        {/* Drawing preview: connecting line */}
+        <Source id="draw-line" type="geojson" data={lineGeoJson}>
+          <Layer
+            id="draw-line-stroke"
+            type="line"
+            paint={{
+              'line-color': '#3b82f6',
+              'line-width': 2,
+              'line-dasharray': [2, 2],
+            }}
+          />
+        </Source>
+
+        {/* Drawing preview: vertex dots */}
+        <Source id="draw-vertices" type="geojson" data={verticesGeoJson}>
+          <Layer
+            id="draw-vertices-circle"
+            type="circle"
+            paint={{
+              'circle-radius': 5,
+              'circle-color': '#3b82f6',
+              'circle-stroke-width': 2,
+              'circle-stroke-color': '#ffffff',
+            }}
+          />
+        </Source>
+
+        {/* Sample points */}
+        <Source id="sample-points" type="geojson" data={pointsGeoJson}>
+          <Layer
+            id="sample-points-circle"
+            type="circle"
+            paint={{
+              'circle-radius': 6,
+              'circle-color': '#e63946',
+              'circle-stroke-width': 2,
+              'circle-stroke-color': '#ffffff',
+            }}
+          />
+          <Layer
+            id="sample-points-label"
+            type="symbol"
+            layout={{
+              'text-field': ['get', 'index'],
+              'text-size': 11,
+              'text-offset': [0, -1.5],
+            }}
+            paint={{ 'text-color': '#1d3557' }}
+          />
+        </Source>
+      </Map>
+
+      {/* Draw control buttons */}
+      <div className="absolute top-2 left-2 flex flex-col gap-1 z-10">
+        {!isDrawing && !polygon && (
+          <button
+            onClick={startDrawing}
+            className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm font-medium text-gray-700 shadow hover:bg-gray-50"
+          >
+            Draw Polygon
+          </button>
+        )}
+        {isDrawing && vertices.length >= 3 && (
+          <button
+            onClick={finishDrawing}
+            className="bg-blue-600 text-white rounded px-3 py-1.5 text-sm font-medium shadow hover:bg-blue-700"
+          >
+            Finish
+          </button>
+        )}
+        {(polygon || isDrawing) && (
+          <button
+            onClick={clearDrawing}
+            className="bg-white border border-gray-300 rounded px-3 py-1.5 text-sm font-medium text-red-600 shadow hover:bg-red-50"
+          >
+            Clear
+          </button>
+        )}
+        {isDrawing && (
+          <span className="bg-white/90 rounded px-2 py-1 text-xs text-gray-500 shadow">
+            Click to add points{vertices.length >= 3 ? ', double-click to finish' : ''}
+          </span>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/hooks/usePolygonDraw.ts
+++ b/src/hooks/usePolygonDraw.ts
@@ -1,0 +1,119 @@
+import { useState, useCallback, useMemo } from 'react';
+import { usePlanStore } from '../stores/planStore';
+
+export function usePolygonDraw() {
+  const [vertices, setVertices] = useState<[number, number][]>([]);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const { polygon, setPolygon } = usePlanStore();
+
+  const startDrawing = useCallback(() => {
+    setVertices([]);
+    setIsDrawing(true);
+    setPolygon(null);
+  }, [setPolygon]);
+
+  const handleClick = useCallback(
+    (lngLat: { lng: number; lat: number }) => {
+      if (!isDrawing) return;
+      setVertices((prev) => [...prev, [lngLat.lng, lngLat.lat]]);
+    },
+    [isDrawing]
+  );
+
+  const finishDrawing = useCallback(() => {
+    if (vertices.length < 3) return;
+    const closed = [...vertices, vertices[0]];
+    const feature: GeoJSON.Feature<GeoJSON.Polygon> = {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'Polygon',
+        coordinates: [closed],
+      },
+    };
+    setPolygon(feature);
+    setIsDrawing(false);
+  }, [vertices, setPolygon]);
+
+  const clearDrawing = useCallback(() => {
+    setVertices([]);
+    setIsDrawing(false);
+    setPolygon(null);
+  }, [setPolygon]);
+
+  // GeoJSON for rendering while drawing
+  const verticesGeoJson: GeoJSON.FeatureCollection = useMemo(
+    () => ({
+      type: 'FeatureCollection',
+      features: vertices.map((v, i) => ({
+        type: 'Feature' as const,
+        properties: { index: i },
+        geometry: { type: 'Point' as const, coordinates: v },
+      })),
+    }),
+    [vertices]
+  );
+
+  const lineGeoJson: GeoJSON.FeatureCollection = useMemo(
+    () => ({
+      type: 'FeatureCollection',
+      features:
+        vertices.length >= 2
+          ? [
+              {
+                type: 'Feature' as const,
+                properties: {},
+                geometry: {
+                  type: 'LineString' as const,
+                  coordinates: vertices,
+                },
+              },
+            ]
+          : [],
+    }),
+    [vertices]
+  );
+
+  const previewPolygonGeoJson: GeoJSON.FeatureCollection = useMemo(
+    () => ({
+      type: 'FeatureCollection',
+      features:
+        vertices.length >= 3
+          ? [
+              {
+                type: 'Feature' as const,
+                properties: {},
+                geometry: {
+                  type: 'Polygon' as const,
+                  coordinates: [[...vertices, vertices[0]]],
+                },
+              },
+            ]
+          : [],
+    }),
+    [vertices]
+  );
+
+  // GeoJSON for rendering the finalized polygon (from store, covers both drawn and KML)
+  const polygonGeoJson: GeoJSON.FeatureCollection = useMemo(
+    () => ({
+      type: 'FeatureCollection',
+      features: polygon && !isDrawing ? [polygon] : [],
+    }),
+    [polygon, isDrawing]
+  );
+
+  return {
+    isDrawing,
+    vertices,
+    polygon,
+    startDrawing,
+    handleClick,
+    finishDrawing,
+    clearDrawing,
+    verticesGeoJson,
+    lineGeoJson,
+    previewPolygonGeoJson,
+    polygonGeoJson,
+  };
+}


### PR DESCRIPTION
@mapbox/mapbox-gl-draw is incompatible with MapLibre GL v5 — click interactions silently fail, making polygon drawing impossible.

Replace with a custom implementation using MapLibre's native click events and GeoJSON source/layer rendering:
- New usePolygonDraw hook manages vertices and drawing state
- PlanMap renders vertex dots, connecting lines, and polygon preview
- Draw/Finish/Clear buttons overlaid on the map
- Double-click to finish drawing
- KML upload integration preserved (renders from store polygon)

https://claude.ai/code/session_014xPs1Nr6T7u3iUsxC4Prjv