### PR TITLE
Add QR code generation to share dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@turf/turf": "^7.3.4",
         "maplibre-gl": "^5.21.0",
         "pako": "^2.1.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-map-gl": "^8.1.0",
@@ -5611,6 +5612,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/quickselect": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@turf/turf": "^7.3.4",
     "maplibre-gl": "^5.21.0",
     "pako": "^2.1.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-map-gl": "^8.1.0",

--- a/src/components/planning/ShareDialog.tsx
+++ b/src/components/planning/ShareDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
 import { usePlanStore } from '../../stores/planStore';
 import { encodePlan } from '../../services/sharing';
 
@@ -22,9 +23,12 @@ export default function ShareDialog({ onClose }: { onClose: () => void }) {
       <div className="bg-white rounded-lg shadow-xl p-6 max-w-lg w-full mx-4">
         <h3 className="text-lg font-semibold mb-2">Share Sampling Plan</h3>
         <p className="text-sm text-gray-600 mb-4">
-          Copy this link and open it on a mobile device to navigate to your
-          sampling points.
+          Scan this QR code or copy the link below to open the plan on a mobile
+          device.
         </p>
+        <div className="flex justify-center mb-4">
+          <QRCodeSVG value={url} size={200} />
+        </div>
         <div className="flex gap-2 mb-4">
           <input
             readOnly


### PR DESCRIPTION
## Summary
Enhanced the ShareDialog component to display a QR code alongside the existing share link, allowing users to quickly scan and open sampling plans on mobile devices.

## Key Changes
- Added `qrcode.react` dependency for QR code generation
- Imported `QRCodeSVG` component in ShareDialog
- Updated dialog description text to mention QR code scanning option
- Added QR code display above the share link input, centered with appropriate spacing
- QR code encodes the same URL as the copy-to-clipboard link

## Implementation Details
- QR code is generated from the existing `url` variable (encoded plan data)
- Set to 200px size for optimal scanning and visibility
- Positioned with flexbox centering and margin spacing for clean layout
- Uses SVG format for crisp rendering at any scale

https://claude.ai/code/session_01SouQnDVjz1vwuu1qGPyjKG