### PR TITLE
Fix compass arrow jumping at 0°/360° boundary

### DIFF
--- a/src/components/navigation/CompassArrow.tsx
+++ b/src/components/navigation/CompassArrow.tsx
@@ -1,14 +1,21 @@
+import { useRef } from 'react';
+
 interface Props {
   rotation: number; // degrees, 0 = up (north)
 }
 
 export default function CompassArrow({ rotation }: Props) {
+  const accRef = useRef(rotation);
+  const prev = accRef.current;
+  const diff = ((rotation - prev + 540) % 360) - 180;
+  accRef.current = prev + diff;
+
   return (
     <div className="flex items-center justify-center w-48 h-48">
       <svg
         viewBox="0 0 100 100"
         className="w-full h-full drop-shadow-lg"
-        style={{ transform: `rotate(${rotation}deg)`, transition: 'transform 0.1s ease-out' }}
+        style={{ transform: `rotate(${accRef.current}deg)`, transition: 'transform 0.1s ease-out' }}
       >
         <polygon
           points="50,10 35,70 50,58 65,70"


### PR DESCRIPTION
## Summary

Fixes #7 — compass arrow jumps significantly when rotating device through 360°.

- **Root cause:** `arrowRotation` is always computed in `[0, 360)`. When crossing the 0°/360° boundary (e.g., 355° → 5°), the value jumps by ~350°. The CSS `transition: transform 0.1s ease-out` animates this as a 350° backward spin instead of a 10° forward movement.
- **Fix:** Added `useRef` accumulation in `CompassArrow.tsx` using the shortest-arc delta trick `((diff + 540) % 360) - 180` — the same technique already used in `useCompass.ts` for sensor smoothing. The accumulated value changes continuously so CSS transitions always animate ≤180°.

## Changes

- `src/components/navigation/CompassArrow.tsx` — only file changed

## Test plan

- [ ] Navigate to a sampling point and rotate device in a full 360° circle — arrow should follow smoothly with no jumps
- [ ] Verify arrow still points toward target correctly at all headings
- [ ] `npm run build` passes with no TypeScript errors

https://claude.ai/code/session_016CXdWKox9zjfaVne3Gqpof