### PR TITLE
feat: add user-configurable cluster count for clustered sampling

### DIFF
--- a/src/algorithms/clustered.ts
+++ b/src/algorithms/clustered.ts
@@ -14,9 +14,10 @@ function randomPointInCircle(center: SamplingPoint, radiusMeters: number): Sampl
 export function generateClustered(
   polygon: GeoJSON.Feature<GeoJSON.Polygon>,
   count: number,
-  minDistance: number
+  minDistance: number,
+  clusterCount: number = 3
 ): SamplingPoint[] {
-  const k = Math.max(2, Math.ceil(count / 5));
+  const k = Math.max(2, clusterCount);
   const centers = generateRandom(polygon, k, minDistance * 3);
 
   if (centers.length === 0) return [];

--- a/src/components/planning/ParameterPanel.tsx
+++ b/src/components/planning/ParameterPanel.tsx
@@ -15,7 +15,7 @@ export default function ParameterPanel({ onShare }: { onShare: () => void }) {
         pts = generateGrid(polygon, params.count, params.minDistance);
         break;
       case 'clustered':
-        pts = generateClustered(polygon, params.count, params.minDistance);
+        pts = generateClustered(polygon, params.count, params.minDistance, params.clusterCount ?? 3);
         break;
       default:
         pts = generateRandom(polygon, params.count, params.minDistance);
@@ -62,6 +62,19 @@ export default function ParameterPanel({ onShare }: { onShare: () => void }) {
           <option value="clustered">Clustered</option>
         </select>
       </label>
+
+      {params.type === 'clustered' && (
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-gray-600">Number of Clusters (2+)</span>
+          <input
+            type="number"
+            className="border border-gray-300 rounded px-3 py-2 text-sm"
+            min={2}
+            value={params.clusterCount ?? 3}
+            onChange={(e) => setParams({ clusterCount: Math.max(2, +e.target.value) })}
+          />
+        </label>
+      )}
 
       <label className="flex flex-col gap-1">
         <span className="text-sm text-gray-600">Min Distance (meters)</span>

--- a/src/stores/planStore.ts
+++ b/src/stores/planStore.ts
@@ -16,6 +16,7 @@ export const usePlanStore = create<PlanState>((set) => ({
     count: 10,
     type: 'random',
     minDistance: 50,
+    clusterCount: 3,
   },
   polygon: null,
   points: [],

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -5,6 +5,7 @@ export interface SamplingParams {
   count: number;
   type: SamplingType;
   minDistance: number; // meters
+  clusterCount?: number; // only used when type === 'clustered'
 }
 
 export interface SamplingPoint {


### PR DESCRIPTION
Resolves #9. When 'Clustered' is selected as the sampling type, a
'Number of Clusters (2+)' input now appears in the parameter panel.
The value defaults to 3 and is clamped to a minimum of 2. It is
passed through to generateClustered(), replacing the hardcoded
formula of ceil(count/5).

https://claude.ai/code/session_012faiREpxwr7msqm1dVh7zE