### PR TITLE
Redesign weather cards with satellite pass integration and cloud cover threshold

### DIFF
--- a/src/components/planning/CalendarStrip.tsx
+++ b/src/components/planning/CalendarStrip.tsx
@@ -1,13 +1,14 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import * as turf from '@turf/turf';
 import { usePlanStore } from '../../stores/planStore';
 import { useWeather } from '../../hooks/useWeather';
 import { useSatellitePasses } from '../../hooks/useSatellitePasses';
+import type { SatellitePass } from '../../services/satellite';
 import WeatherDay from './WeatherDay';
-import SatellitePassIndicator from './SatellitePassIndicator';
 
 export default function CalendarStrip() {
   const polygon = usePlanStore((s) => s.polygon);
+  const [cloudThreshold, setCloudThreshold] = useState(30);
 
   const centroid = useMemo(() => {
     if (!polygon) return null;
@@ -24,6 +25,15 @@ export default function CalendarStrip() {
     centroid?.lng ?? null
   );
 
+  const passesByDate = useMemo(() => {
+    const map = new Map<string, SatellitePass[]>();
+    for (const pass of passes) {
+      const key = pass.time.toLocaleDateString('en-CA');
+      map.set(key, [...(map.get(key) ?? []), pass]);
+    }
+    return map;
+  }, [passes]);
+
   if (!polygon) {
     return (
       <div className="h-28 bg-gray-50 border-t border-gray-200 flex items-center justify-center text-sm text-gray-400">
@@ -34,17 +44,35 @@ export default function CalendarStrip() {
 
   return (
     <div className="bg-white border-t border-gray-200">
-      <div className="flex items-center gap-2 px-3 py-1">
+      <div className="flex items-center gap-3 px-3 py-2 border-b border-gray-100">
         <span className="text-xs font-medium text-gray-500 shrink-0">14-Day Forecast</span>
-        <SatellitePassIndicator passes={passes} />
+        <div className="flex items-center gap-2 ml-auto">
+          <span className="text-xs text-gray-500 shrink-0">☁️ Clear pass &lt;</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={cloudThreshold}
+            onChange={(e) => setCloudThreshold(Number(e.target.value))}
+            className="w-24 accent-green-500"
+          />
+          <span className="text-xs font-medium text-gray-700 w-8 text-right">{cloudThreshold}%</span>
+        </div>
       </div>
-      <div className="flex overflow-x-auto px-2 pb-2">
+      <div className="flex overflow-x-auto gap-2 px-2 py-2">
         {weatherLoading && (
           <div className="flex items-center justify-center w-full py-4 text-sm text-gray-400">
             Loading weather...
           </div>
         )}
-        {weather?.map((day) => <WeatherDay key={day.date} day={day} />)}
+        {weather?.map((day) => (
+          <WeatherDay
+            key={day.date}
+            day={day}
+            passes={passesByDate.get(day.date) ?? []}
+            cloudThreshold={cloudThreshold}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/components/planning/WeatherDay.tsx
+++ b/src/components/planning/WeatherDay.tsx
@@ -1,22 +1,63 @@
 import type { DailyWeather } from '../../services/weather';
 import { weatherCodeToLabel } from '../../services/weather';
+import type { SatellitePass } from '../../services/satellite';
 
-export default function WeatherDay({ day }: { day: DailyWeather }) {
+interface WeatherDayProps {
+  day: DailyWeather;
+  passes: SatellitePass[];
+  cloudThreshold: number;
+}
+
+export default function WeatherDay({ day, passes, cloudThreshold }: WeatherDayProps) {
   const { icon } = weatherCodeToLabel(day.weatherCode);
   const date = new Date(day.date + 'T00:00:00');
   const dayName = date.toLocaleDateString('en', { weekday: 'short' });
   const dayNum = date.getDate();
 
+  const isClearPass = passes.length > 0 && day.cloudCover < cloudThreshold;
+  const cardClass = isClearPass
+    ? 'bg-green-50 ring-2 ring-green-400'
+    : 'bg-white border border-gray-200';
+
   return (
-    <div className="flex flex-col items-center gap-0.5 min-w-[60px] px-2 py-1.5">
-      <span className="text-xs text-gray-500">{dayName}</span>
-      <span className="text-sm font-medium">{dayNum}</span>
-      <span className="text-xl">{icon}</span>
-      <span className="text-xs text-gray-600">
-        {Math.round(day.tempMax)}° / {Math.round(day.tempMin)}°
+    <div className={`flex flex-col gap-1 min-w-[120px] rounded-lg px-3 py-2 ${cardClass}`}>
+      <div className="flex justify-between items-center">
+        <span className="text-xs text-gray-500">{dayName}</span>
+        <span className="text-sm font-semibold">{dayNum}</span>
+      </div>
+
+      <span className="text-2xl text-center">{icon}</span>
+
+      <span className="text-xs text-gray-600 text-center">
+        ↑{Math.round(day.tempMax)}° ↓{Math.round(day.tempMin)}°
       </span>
+
+      <span className={`text-xs text-center ${day.cloudCover < cloudThreshold ? 'text-green-600 font-medium' : 'text-gray-400'}`}>
+        ☁️ {day.cloudCover}%
+      </span>
+
       {day.precipProb > 0 && (
-        <span className="text-xs text-blue-500">{day.precipProb}%</span>
+        <span className="text-xs text-blue-500 text-center">💧{day.precipProb}%</span>
+      )}
+
+      {passes.length > 0 && (
+        <div className="mt-1 pt-1 border-t border-gray-200 flex flex-col gap-0.5">
+          {passes.map((pass, i) => (
+            <span key={i} className="text-xs text-indigo-700 flex items-center gap-0.5">
+              🛰️
+              <span className="font-medium">{pass.satellite.replace('Sentinel-', 'S')}</span>
+              <span className="text-gray-500 ml-0.5">
+                {pass.time.toLocaleTimeString('en', { hour: '2-digit', minute: '2-digit' })}
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {isClearPass && (
+        <span className="text-[10px] font-bold text-green-700 text-center uppercase tracking-wide mt-0.5">
+          Clear Pass
+        </span>
       )}
     </div>
   );

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -5,6 +5,7 @@ export interface DailyWeather {
   tempMin: number;
   precipSum: number;
   precipProb: number;
+  cloudCover: number;
 }
 
 export async function fetchWeather(
@@ -16,7 +17,7 @@ export async function fetchWeather(
   url.searchParams.set('longitude', lng.toFixed(4));
   url.searchParams.set(
     'daily',
-    'weathercode,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max'
+    'weathercode,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,cloudcover_mean'
   );
   url.searchParams.set('timezone', 'auto');
   url.searchParams.set('forecast_days', '14');
@@ -34,6 +35,7 @@ export async function fetchWeather(
       tempMin: d.temperature_2m_min[i],
       precipSum: d.precipitation_sum[i],
       precipProb: d.precipitation_probability_max[i],
+      cloudCover: d.cloudcover_mean[i] ?? 100,
     });
   }
   return days;


### PR DESCRIPTION
- Add cloudCover field to DailyWeather (fetched from Open-Meteo cloudcover_mean)
- Redesign WeatherDay as a larger card showing cloud cover % and per-day satellite passes
- Highlight cards green with "Clear Pass" badge when a satellite transit coincides with cloud cover below threshold
- Add cloud cover threshold slider (default 30%) to CalendarStrip header
- Replace standalone SatellitePassIndicator with inline per-card pass display

Resolves #10

https://claude.ai/code/session_018qW6qoFhMnYnAuHNQMgJ28