### PR TITLE
Fix satellite transit timezone and exclude nighttime passes

### DIFF
--- a/src/components/planning/CalendarStrip.tsx
+++ b/src/components/planning/CalendarStrip.tsx
@@ -16,23 +16,42 @@ export default function CalendarStrip() {
     return { lat: c.geometry.coordinates[1], lng: c.geometry.coordinates[0] };
   }, [polygon]);
 
-  const { data: weather, loading: weatherLoading } = useWeather(
+  const { data: weatherResult, loading: weatherLoading } = useWeather(
     centroid?.lat ?? null,
     centroid?.lng ?? null
   );
+  const weather = weatherResult?.days ?? null;
+  const timezone = weatherResult?.timezone ?? 'UTC';
   const { passes } = useSatellitePasses(
     centroid?.lat ?? null,
     centroid?.lng ?? null
   );
 
   const passesByDate = useMemo(() => {
+    const sunTimes = new Map<string, { sunrise: string; sunset: string }>();
+    if (weather) {
+      for (const day of weather) {
+        sunTimes.set(day.date, {
+          sunrise: day.sunrise.slice(11),
+          sunset: day.sunset.slice(11),
+        });
+      }
+    }
+
     const map = new Map<string, SatellitePass[]>();
     for (const pass of passes) {
-      const key = pass.time.toLocaleDateString('en-CA');
+      const key = pass.time.toLocaleDateString('en-CA', { timeZone: timezone });
+      const sun = sunTimes.get(key);
+      if (sun) {
+        const localTime = pass.time.toLocaleTimeString('en-CA', {
+          hour12: false, hour: '2-digit', minute: '2-digit', timeZone: timezone,
+        });
+        if (localTime < sun.sunrise || localTime > sun.sunset) continue;
+      }
       map.set(key, [...(map.get(key) ?? []), pass]);
     }
     return map;
-  }, [passes]);
+  }, [passes, weather, timezone]);
 
   if (!polygon) {
     return (
@@ -71,6 +90,7 @@ export default function CalendarStrip() {
             day={day}
             passes={passesByDate.get(day.date) ?? []}
             cloudThreshold={cloudThreshold}
+            timezone={timezone}
           />
         ))}
       </div>

--- a/src/components/planning/SatellitePassIndicator.tsx
+++ b/src/components/planning/SatellitePassIndicator.tsx
@@ -1,6 +1,6 @@
 import type { SatellitePass } from '../../services/satellite';
 
-export default function SatellitePassIndicator({ passes }: { passes: SatellitePass[] }) {
+export default function SatellitePassIndicator({ passes, timezone }: { passes: SatellitePass[]; timezone?: string }) {
   if (passes.length === 0) return null;
 
   return (
@@ -10,8 +10,8 @@ export default function SatellitePassIndicator({ passes }: { passes: SatellitePa
         {passes.slice(0, 3).map((pass, i) => (
           <span key={i}>
             {pass.satellite}:{' '}
-            {pass.time.toLocaleDateString('en', { month: 'short', day: 'numeric' })}{' '}
-            {pass.time.toLocaleTimeString('en', { hour: '2-digit', minute: '2-digit' })}
+            {pass.time.toLocaleDateString('en', { month: 'short', day: 'numeric', timeZone: timezone })}{' '}
+            {pass.time.toLocaleTimeString('en', { hour: '2-digit', minute: '2-digit', timeZone: timezone })}
           </span>
         ))}
         {passes.length > 3 && <span>+{passes.length - 3} more passes</span>}

--- a/src/components/planning/WeatherDay.tsx
+++ b/src/components/planning/WeatherDay.tsx
@@ -6,9 +6,10 @@ interface WeatherDayProps {
   day: DailyWeather;
   passes: SatellitePass[];
   cloudThreshold: number;
+  timezone: string;
 }
 
-export default function WeatherDay({ day, passes, cloudThreshold }: WeatherDayProps) {
+export default function WeatherDay({ day, passes, cloudThreshold, timezone }: WeatherDayProps) {
   const { icon } = weatherCodeToLabel(day.weatherCode);
   const date = new Date(day.date + 'T00:00:00');
   const dayName = date.toLocaleDateString('en', { weekday: 'short' });
@@ -47,7 +48,7 @@ export default function WeatherDay({ day, passes, cloudThreshold }: WeatherDayPr
               🛰️
               <span className="font-medium">{pass.satellite.replace('Sentinel-', 'S')}</span>
               <span className="text-gray-500 ml-0.5">
-                {pass.time.toLocaleTimeString('en', { hour: '2-digit', minute: '2-digit' })}
+                {pass.time.toLocaleTimeString('en', { hour: '2-digit', minute: '2-digit', timeZone: timezone })}
               </span>
             </span>
           ))}

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
-import { fetchWeather, type DailyWeather } from '../services/weather';
+import { fetchWeather, type WeatherResult } from '../services/weather';
 
 export function useWeather(lat: number | null, lng: number | null) {
-  const [data, setData] = useState<DailyWeather[] | null>(null);
+  const [data, setData] = useState<WeatherResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -6,18 +6,25 @@ export interface DailyWeather {
   precipSum: number;
   precipProb: number;
   cloudCover: number;
+  sunrise: string;
+  sunset: string;
+}
+
+export interface WeatherResult {
+  days: DailyWeather[];
+  timezone: string;
 }
 
 export async function fetchWeather(
   lat: number,
   lng: number
-): Promise<DailyWeather[]> {
+): Promise<WeatherResult> {
   const url = new URL('https://api.open-meteo.com/v1/forecast');
   url.searchParams.set('latitude', lat.toFixed(4));
   url.searchParams.set('longitude', lng.toFixed(4));
   url.searchParams.set(
     'daily',
-    'weathercode,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,cloudcover_mean'
+    'weathercode,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,cloudcover_mean,sunrise,sunset'
   );
   url.searchParams.set('timezone', 'auto');
   url.searchParams.set('forecast_days', '14');
@@ -36,9 +43,11 @@ export async function fetchWeather(
       precipSum: d.precipitation_sum[i],
       precipProb: d.precipitation_probability_max[i],
       cloudCover: d.cloudcover_mean[i] ?? 100,
+      sunrise: d.sunrise[i],
+      sunset: d.sunset[i],
     });
   }
-  return days;
+  return { days, timezone: data.timezone };
 }
 
 export function weatherCodeToLabel(code: number): { label: string; icon: string } {


### PR DESCRIPTION
## Summary

- **Timezone fix (#18)**: Satellite pass times are now displayed in the sampling location's timezone instead of the browser's local timezone, using the `timeZone` option from `Intl.DateTimeFormat` with the timezone returned by the Open-Meteo API
- **Nighttime filter (#19)**: Satellite passes occurring between sunset and sunrise are excluded, since Sentinel-2 is an optical satellite that cannot image in darkness. Sunrise/sunset data is fetched from the Open-Meteo API alongside existing weather parameters
- Updated `SatellitePassIndicator` component for timezone consistency

Fixes #18, fixes #19

## Test plan

- [ ] Draw a polygon in a timezone different from your browser's — verify pass times reflect the location's local time, not your browser's
- [ ] Check that no satellite passes appear during nighttime hours (before sunrise or after sunset)
- [ ] Verify the weather calendar strip still loads correctly with cloud cover, precipitation, and pass indicators
- [ ] Confirm "Clear Pass" highlighting still works when cloud cover is below threshold and a daytime pass exists

https://claude.ai/code/session_019yp3wTYnyGyQA1kW4RXtQV