### PR TITLE
Add warning when min distance prevents placing all points

### DIFF
--- a/src/components/planning/ParameterPanel.tsx
+++ b/src/components/planning/ParameterPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { usePlanStore } from '../../stores/planStore';
 import { generateRandom } from '../../algorithms/random';
 import { generateGrid } from '../../algorithms/grid';
@@ -25,6 +26,7 @@ export default function ParameterPanel({
   clearDrawing,
 }: ParameterPanelProps) {
   const { params, polygon: storePolygon, setParams, setPoints } = usePlanStore();
+  const [warning, setWarning] = useState<string | null>(null);
 
   const handleGenerate = () => {
     if (!storePolygon) return;
@@ -40,6 +42,13 @@ export default function ParameterPanel({
         pts = generateRandom(storePolygon, params.count, params.minDistance);
     }
     setPoints(pts);
+    if (pts.length < params.count) {
+      setWarning(
+        `Only ${pts.length} of ${params.count} points could be placed. Try reducing the minimum distance or the number of points.`
+      );
+    } else {
+      setWarning(null);
+    }
   };
 
   return (
@@ -149,6 +158,12 @@ export default function ParameterPanel({
       >
         Generate Points
       </button>
+
+      {warning && (
+        <div className="bg-amber-50 border border-amber-300 text-amber-800 rounded px-3 py-2 text-sm">
+          {warning}
+        </div>
+      )}
 
       <button
         onClick={onShare}


### PR DESCRIPTION
## Summary

- Adds an amber warning banner in the parameter panel when the sampling algorithm places fewer points than requested due to the minimum distance constraint
- The warning shows how many points were placed vs. requested and suggests reducing the min distance or point count
- Warning clears automatically when generation succeeds with all requested points

Closes #23

## Test plan

- [ ] Draw a small polygon, set high min distance (e.g. 500m) with many points (e.g. 50), click Generate — warning should appear
- [ ] Generate again with feasible parameters — warning should disappear
- [ ] Verify build passes with `npm run build`

https://claude.ai/code/session_011R7QkJLGu1p7AoGbdrBJWR