### PR TITLE
feat: add minimum cluster distance parameter for clustered sampling

### DIFF
--- a/src/algorithms/clustered.ts
+++ b/src/algorithms/clustered.ts
@@ -15,10 +15,11 @@ export function generateClustered(
   polygon: GeoJSON.Feature<GeoJSON.Polygon>,
   count: number,
   minDistance: number,
-  clusterCount: number = 3
+  clusterCount: number = 3,
+  minClusterDistance: number = 0
 ): SamplingPoint[] {
   const k = Math.max(2, clusterCount);
-  const centers = generateRandom(polygon, k, minDistance * 3);
+  const centers = generateRandom(polygon, k, minClusterDistance > 0 ? minClusterDistance : minDistance * 3);
 
   if (centers.length === 0) return [];
 

--- a/src/components/planning/ParameterPanel.tsx
+++ b/src/components/planning/ParameterPanel.tsx
@@ -36,7 +36,7 @@ export default function ParameterPanel({
         pts = generateGrid(storePolygon, params.count, params.minDistance);
         break;
       case 'clustered':
-        pts = generateClustered(storePolygon, params.count, params.minDistance, params.clusterCount ?? 3);
+        pts = generateClustered(storePolygon, params.count, params.minDistance, params.clusterCount ?? 3, params.minClusterDistance ?? 150);
         break;
       default:
         pts = generateRandom(storePolygon, params.count, params.minDistance);
@@ -136,6 +136,19 @@ export default function ParameterPanel({
             min={2}
             value={params.clusterCount ?? 3}
             onChange={(e) => setParams({ clusterCount: Math.max(2, +e.target.value) })}
+          />
+        </label>
+      )}
+
+      {params.type === 'clustered' && (
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-gray-600">Min Cluster Distance (meters)</span>
+          <input
+            type="number"
+            className="border border-gray-300 rounded px-3 py-2 text-sm"
+            min={0}
+            value={params.minClusterDistance ?? 150}
+            onChange={(e) => setParams({ minClusterDistance: Math.max(0, +e.target.value) })}
           />
         </label>
       )}

--- a/src/stores/planStore.ts
+++ b/src/stores/planStore.ts
@@ -17,6 +17,7 @@ export const usePlanStore = create<PlanState>((set) => ({
     type: 'random',
     minDistance: 50,
     clusterCount: 3,
+    minClusterDistance: 150,
   },
   polygon: null,
   points: [],

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -6,6 +6,7 @@ export interface SamplingParams {
   type: SamplingType;
   minDistance: number; // meters
   clusterCount?: number; // only used when type === 'clustered'
+  minClusterDistance?: number; // only used when type === 'clustered'
 }
 
 export interface SamplingPoint {


### PR DESCRIPTION
Adds a user-configurable minClusterDistance parameter that controls the
minimum distance (in meters) between cluster centroids when using the
clustered sampling type. Previously this was hardcoded as minDistance * 3.

Closes #28