### PR TITLE
Add W sampling pattern

### DIFF
--- a/src/algorithms/w.ts
+++ b/src/algorithms/w.ts
@@ -1,0 +1,81 @@
+import * as turf from '@turf/turf';
+import type { SamplingPoint } from '../types/plan';
+import { isInsidePolygon, satisfiesMinDistance } from './common';
+
+export function generateW(
+  polygon: GeoJSON.Feature<GeoJSON.Polygon>,
+  count: number,
+  minDistance: number
+): SamplingPoint[] {
+  const bbox = turf.bbox(polygon);
+  const [minLng, minLat, maxLng, maxLat] = bbox;
+
+  // Define W shape vertices within the bounding box with some inset
+  const insetX = (maxLng - minLng) * 0.05;
+  const insetY = (maxLat - minLat) * 0.05;
+  const left = minLng + insetX;
+  const right = maxLng - insetX;
+  const top = maxLat - insetY;
+  const bottom = minLat + insetY;
+  const midX = (left + right) / 2;
+  const quarterX = (left + midX) / 2;
+  const threeQuarterX = (midX + right) / 2;
+
+  // W shape: top-left -> bottom-quarter -> top-center -> bottom-three-quarter -> top-right
+  const wVertices: [number, number][] = [
+    [left, top],
+    [quarterX, bottom],
+    [midX, top],
+    [threeQuarterX, bottom],
+    [right, top],
+  ];
+
+  const line = turf.lineString(wVertices);
+  const totalLength = turf.length(line, { units: 'kilometers' });
+
+  // Generate more candidate points than needed to account for polygon clipping
+  const overSample = Math.max(count * 3, 50);
+  const candidates: SamplingPoint[] = [];
+
+  for (let i = 0; i < overSample; i++) {
+    const distance = (i / (overSample - 1)) * totalLength;
+    const pt = turf.along(line, distance, { units: 'kilometers' });
+    const [lng, lat] = pt.geometry.coordinates;
+    candidates.push({ lng, lat });
+  }
+
+  // Filter to points inside the polygon
+  const inside = candidates.filter((pt) => isInsidePolygon(pt, polygon));
+
+  // Select evenly spaced points from the filtered set
+  const points: SamplingPoint[] = [];
+  if (inside.length <= count) {
+    // Use all available points that satisfy min distance
+    for (const pt of inside) {
+      if (satisfiesMinDistance(pt, points, minDistance)) {
+        points.push(pt);
+      }
+    }
+  } else {
+    // Pick evenly spaced points from the inside set
+    for (let i = 0; i < count; i++) {
+      const idx = Math.round((i / (count - 1)) * (inside.length - 1));
+      const pt = inside[idx];
+      if (satisfiesMinDistance(pt, points, minDistance)) {
+        points.push(pt);
+      }
+    }
+
+    // If we didn't get enough due to min distance, fill from remaining candidates
+    if (points.length < count) {
+      for (const pt of inside) {
+        if (points.length >= count) break;
+        if (satisfiesMinDistance(pt, points, minDistance)) {
+          points.push(pt);
+        }
+      }
+    }
+  }
+
+  return points;
+}

--- a/src/components/planning/ParameterPanel.tsx
+++ b/src/components/planning/ParameterPanel.tsx
@@ -3,6 +3,7 @@ import { usePlanStore } from '../../stores/planStore';
 import { generateRandom } from '../../algorithms/random';
 import { generateGrid } from '../../algorithms/grid';
 import { generateClustered } from '../../algorithms/clustered';
+import { generateW } from '../../algorithms/w';
 import type { SamplingType } from '../../types/plan';
 import KmlUploader from './KmlUploader';
 
@@ -37,6 +38,9 @@ export default function ParameterPanel({
         break;
       case 'clustered':
         pts = generateClustered(storePolygon, params.count, params.minDistance, params.clusterCount ?? 3, params.minClusterDistance ?? 150);
+        break;
+      case 'w':
+        pts = generateW(storePolygon, params.count, params.minDistance);
         break;
       default:
         pts = generateRandom(storePolygon, params.count, params.minDistance);
@@ -124,6 +128,7 @@ export default function ParameterPanel({
           <option value="random">Random</option>
           <option value="grid">Grid</option>
           <option value="clustered">Clustered</option>
+          <option value="w">W Pattern</option>
         </select>
       </label>
 

--- a/src/services/sharing.ts
+++ b/src/services/sharing.ts
@@ -1,16 +1,18 @@
 import { compress, decompress } from '../lib/compression';
 import type { SamplingPoint, SamplingType, SharePayload } from '../types/plan';
 
-const TYPE_MAP: Record<SamplingType, 'r' | 'g' | 'c'> = {
+const TYPE_MAP: Record<SamplingType, 'r' | 'g' | 'c' | 'w'> = {
   random: 'r',
   grid: 'g',
   clustered: 'c',
+  w: 'w',
 };
 
 const REVERSE_TYPE_MAP: Record<string, SamplingType> = {
   r: 'random',
   g: 'grid',
   c: 'clustered',
+  w: 'w',
 };
 
 export function encodePlan(

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -1,4 +1,4 @@
-export type SamplingType = 'random' | 'grid' | 'clustered';
+export type SamplingType = 'random' | 'grid' | 'clustered' | 'w';
 
 export interface SamplingParams {
   name: string;
@@ -24,5 +24,5 @@ export interface SharePayload {
   v: 1;
   n: string;
   p: [number, number][]; // [lng, lat] pairs
-  t: 'r' | 'g' | 'c';
+  t: 'r' | 'g' | 'c' | 'w';
 }


### PR DESCRIPTION
## Summary
- Adds a new W-shaped sampling pattern algorithm (`src/algorithms/w.ts`) that distributes points along a W path across the polygon, a standard technique in environmental/agricultural sampling
- Integrates the new pattern into the type system, sharing service, and UI dropdown

Closes #17

## Test plan
- [ ] Select "W Pattern" from the sampling type dropdown
- [ ] Draw a polygon and generate points — verify they follow a W-shaped distribution
- [ ] Test with varying point counts and min distances
- [ ] Share a W pattern plan and verify it decodes correctly on the navigate view
- [ ] Verify existing patterns (random, grid, clustered) still work unchanged

https://claude.ai/code/session_012ZcF7dwMyEv7LwtYNyCJxK