### PR TITLE
Fix compass flicker on mobile navigation

### DIFF
--- a/src/components/navigation/CompassArrow.tsx
+++ b/src/components/navigation/CompassArrow.tsx
@@ -1,21 +1,43 @@
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 
 interface Props {
   rotation: number; // degrees, 0 = up (north)
 }
 
 export default function CompassArrow({ rotation }: Props) {
-  const accRef = useRef(rotation);
-  const prev = accRef.current;
-  const diff = ((rotation - prev + 540) % 360) - 180;
-  accRef.current = prev + diff;
+  const svgRef = useRef<SVGSVGElement>(null);
+  const displayAngle = useRef(rotation);
+  const targetAngle = useRef(rotation);
+  const prevProp = useRef(rotation);
+
+  // Unwrap rotation prop into continuous target angle (avoids 359→1 jumps)
+  const propDiff = ((rotation - prevProp.current + 540) % 360) - 180;
+  targetAngle.current += propDiff;
+  prevProp.current = rotation;
+
+  // Persistent rAF loop — single source of visual animation
+  useEffect(() => {
+    let rafId: number;
+    const ALPHA = 0.18;
+
+    function animate() {
+      const diff = targetAngle.current - displayAngle.current;
+      displayAngle.current += ALPHA * diff;
+      if (svgRef.current) {
+        svgRef.current.style.transform = `rotate(${displayAngle.current}deg)`;
+      }
+      rafId = requestAnimationFrame(animate);
+    }
+    rafId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(rafId);
+  }, []);
 
   return (
     <div className="flex items-center justify-center w-48 h-48">
       <svg
+        ref={svgRef}
         viewBox="0 0 100 100"
         className="w-full h-full drop-shadow-lg"
-        style={{ transform: `rotate(${accRef.current}deg)`, transition: 'transform 0.1s ease-out' }}
       >
         <polygon
           points="50,10 35,70 50,58 65,70"

--- a/src/hooks/useCompass.ts
+++ b/src/hooks/useCompass.ts
@@ -5,6 +5,7 @@ export function useCompass() {
   const [error, setError] = useState<string | null>(null);
   const [needsPermission, setNeedsPermission] = useState(false);
   const smoothRef = useRef(0);
+  const rafRef = useRef<number>(0);
 
   const handleOrientation = useCallback((event: DeviceOrientationEvent) => {
     let raw: number | null = null;
@@ -23,7 +24,14 @@ export function useCompass() {
       const diff = raw - smoothRef.current;
       const wrapped = ((diff + 540) % 360) - 180;
       smoothRef.current = (smoothRef.current + 0.15 * wrapped + 360) % 360;
-      setHeading(smoothRef.current);
+
+      // Throttle React state updates to one per animation frame
+      if (!rafRef.current) {
+        rafRef.current = requestAnimationFrame(() => {
+          setHeading(smoothRef.current);
+          rafRef.current = 0;
+        });
+      }
     }
   }, []);
 
@@ -59,7 +67,10 @@ export function useCompass() {
     const eventName = hasAbsolute ? 'deviceorientationabsolute' : 'deviceorientation';
 
     window.addEventListener(eventName, handler, true);
-    return () => window.removeEventListener(eventName, handler, true);
+    return () => {
+      window.removeEventListener(eventName, handler, true);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
   }, [handleOrientation]);
 
   return { heading, error, needsPermission, requestPermission };

--- a/src/routes/NavigateView.tsx
+++ b/src/routes/NavigateView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useCallback, useRef } from 'react';
+import { useEffect, useMemo, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { decodePlan } from '../services/sharing';
 import { useNavStore } from '../stores/navStore';
@@ -103,16 +103,10 @@ export default function NavigateView() {
     return calcBearing(position, target);
   }, [position, target]);
 
-  const rawRotation = useMemo(() => {
+  const arrowRotation = useMemo(() => {
     if (heading === null) return bearingToTarget;
     return ((bearingToTarget - heading + 720) % 360);
   }, [bearingToTarget, heading]);
-
-  // Smooth arrow rotation to dampen GPS position noise in bearing calc
-  const smoothRotRef = useRef(rawRotation);
-  const diff = ((rawRotation - smoothRotRef.current + 540) % 360) - 180;
-  smoothRotRef.current = (smoothRotRef.current + 0.35 * diff + 360) % 360;
-  const arrowRotation = smoothRotRef.current;
 
   const handleMarkComplete = useCallback(() => {
     if (currentTargetId !== null) {


### PR DESCRIPTION
## Summary

- **Root cause**: Three competing animation layers (useCompass EMA smoothing → NavigateView render-time EMA → CompassArrow CSS transition) conflicted with each other. The 100ms CSS transition was restarted every ~16ms by JS smoothing updates, creating stutter — especially when pointing away from the target where GPS bearing noise sensitivity is highest.
- **Fix**: Consolidate all visual animation into a single `requestAnimationFrame` loop in CompassArrow that smoothly interpolates via direct DOM manipulation, eliminating the conflicting CSS transition and redundant JS smoothing layer.
- **useCompass**: Throttle `setHeading()` to rAF rate to reduce unnecessary re-renders from ~60Hz sensor events.

## Test plan

- [ ] Deploy to mobile device and verify compass arrow is smooth when slowly spinning the phone
- [ ] Verify no flicker when device points directly away from the target sample (worst case for GPS noise)
- [ ] Verify arrow remains stable when phone is held still
- [ ] Verify arrow still responds promptly to direction changes (~1s settle time)
- [ ] Verify `npm run build` passes with no TypeScript errors

Fixes #33

https://claude.ai/code/session_013sBqTz4co5XjR6CWAdQrSG