### PR TITLE
Move directions button into mini map overlay

### DIFF
--- a/src/components/navigation/DirectionsButton.tsx
+++ b/src/components/navigation/DirectionsButton.tsx
@@ -11,9 +11,17 @@ export default function DirectionsButton({ lat, lng }: Props) {
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="block w-full py-3 rounded-xl text-base font-semibold text-center border-2 border-blue-600 text-blue-600 hover:bg-blue-50 transition-all"
+      className="flex items-center justify-center w-10 h-10 rounded-full bg-white shadow-md border border-gray-200 text-blue-600 hover:bg-blue-50 transition-all"
+      aria-label="Get Directions"
     >
-      Get Directions
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="w-5 h-5"
+      >
+        <path d="M22.46 10.46l-8.92-8.92a1.5 1.5 0 0 0-2.12 0L2.5 10.46a1.5 1.5 0 0 0 0 2.12l8.92 8.92a1.5 1.5 0 0 0 2.12 0l8.92-8.92a1.5 1.5 0 0 0 0-2.12zM13 17h-2v-2h2v2zm0-4h-2V7h2v6z" />
+      </svg>
     </a>
   );
 }

--- a/src/components/navigation/NavMiniMap.tsx
+++ b/src/components/navigation/NavMiniMap.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import Map, { Source, Layer, Marker } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { NavPoint } from '../../types/navigation';
+import DirectionsButton from './DirectionsButton';
 
 interface Props {
   points: NavPoint[];
@@ -9,6 +10,7 @@ interface Props {
   currentTargetId: number | null;
   userLat: number | null;
   userLng: number | null;
+  centroid: { lat: number; lng: number } | null;
 }
 
 export default function NavMiniMap({
@@ -17,6 +19,7 @@ export default function NavMiniMap({
   currentTargetId,
   userLat,
   userLng,
+  centroid,
 }: Props) {
   const geojson: GeoJSON.FeatureCollection = useMemo(
     () => ({
@@ -44,7 +47,12 @@ export default function NavMiniMap({
   }, [points, userLat, userLng]);
 
   return (
-    <div className="w-full h-48 rounded-lg overflow-hidden border border-gray-200">
+    <div className="relative w-full h-48 rounded-lg overflow-hidden border border-gray-200">
+      {centroid && (
+        <div className="absolute top-2 right-2 z-10">
+          <DirectionsButton lat={centroid.lat} lng={centroid.lng} />
+        </div>
+      )}
       <Map
         longitude={center.lng}
         latitude={center.lat}

--- a/src/routes/NavigateView.tsx
+++ b/src/routes/NavigateView.tsx
@@ -12,7 +12,7 @@ import PointProgress from '../components/navigation/PointProgress';
 import MarkCompleteButton from '../components/navigation/MarkCompleteButton';
 import CompletionNotice from '../components/navigation/CompletionNotice';
 import NavMiniMap from '../components/navigation/NavMiniMap';
-import DirectionsButton from '../components/navigation/DirectionsButton';
+
 
 export default function NavigateView() {
   const { data } = useParams<{ data: string }>();
@@ -175,8 +175,6 @@ export default function NavigateView() {
 
       <PointProgress completed={completedIds.size} total={points.length} />
 
-      {centroid && <DirectionsButton lat={centroid.lat} lng={centroid.lng} />}
-
       <MarkCompleteButton
         onMark={handleMarkComplete}
         isNear={dist !== null && dist < 5}
@@ -188,6 +186,7 @@ export default function NavigateView() {
         currentTargetId={currentTargetId}
         userLat={position?.lat ?? null}
         userLng={position?.lng ?? null}
+        centroid={centroid}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Replaces the full-width "Get Directions" button with a compact icon overlaid on the NavMiniMap corner (top-right)
- Frees up vertical screen space on mobile while keeping directions easily accessible
- Closes #39

## Test plan
- [ ] Open navigation view on mobile (or mobile emulator)
- [ ] Verify the full-width "Get Directions" button is no longer visible
- [ ] Verify a small circular directions icon appears in the top-right corner of the mini map
- [ ] Tap the icon and confirm it opens Google Maps directions to the sample area centroid
- [ ] Verify other UI elements (compass, distance, mark complete, progress bar) are unaffected

https://claude.ai/code/session_01WcnyJwdWTg8NYqffnTPefp