### PR TITLE
Fix: remove inapplicable minimum distance constraint from grid and SSUS algorithms

### DIFF
--- a/src/algorithms/grid.ts
+++ b/src/algorithms/grid.ts
@@ -3,12 +3,10 @@ import type { SamplingPoint } from '../types/plan';
 
 export function generateGrid(
   polygon: GeoJSON.Feature<GeoJSON.Polygon>,
-  count: number,
-  minDistance: number
+  count: number
 ): SamplingPoint[] {
   const area = turf.area(polygon);
   let cellSize = Math.sqrt(area / count);
-  cellSize = Math.max(cellSize, minDistance);
 
   // Iteratively adjust cell size to converge on target count
   for (let iteration = 0; iteration < 10; iteration++) {

--- a/src/algorithms/ssus.ts
+++ b/src/algorithms/ssus.ts
@@ -1,6 +1,6 @@
 import * as turf from '@turf/turf';
 import type { SamplingPoint } from '../types/plan';
-import { isInsidePolygon, satisfiesMinDistance } from './common';
+import { isInsidePolygon } from './common';
 
 function computeGrid(polygon: GeoJSON.Feature<GeoJSON.Polygon>, count: number) {
   const [minLng, minLat, maxLng, maxLat] = turf.bbox(polygon);
@@ -26,8 +26,7 @@ function computeGrid(polygon: GeoJSON.Feature<GeoJSON.Polygon>, count: number) {
 
 export function generateSSUS(
   polygon: GeoJSON.Feature<GeoJSON.Polygon>,
-  count: number,
-  minDistance: number
+  count: number
 ): SamplingPoint[] {
   if (count <= 0) return [];
 
@@ -51,10 +50,7 @@ export function generateSSUS(
         lat: minLat + i * cellH + yOffsets[j],
       };
 
-      if (
-        isInsidePolygon(candidate, polygon) &&
-        satisfiesMinDistance(candidate, points, minDistance)
-      ) {
+      if (isInsidePolygon(candidate, polygon)) {
         points.push(candidate);
         if (points.length >= count) return points;
       }

--- a/src/components/planning/ParameterPanel.tsx
+++ b/src/components/planning/ParameterPanel.tsx
@@ -162,15 +162,17 @@ export default function ParameterPanel({
           </FormField>
         )}
 
-        <FormField label="Min Distance (meters)">
-          <input
-            type="number"
-            className={fieldClass}
-            min={0}
-            value={params.minDistance}
-            onChange={(e) => setParams({ minDistance: Math.max(0, +e.target.value) })}
-          />
-        </FormField>
+        {params.type !== 'grid' && params.type !== 'ssus' && (
+          <FormField label="Min Distance (meters)">
+            <input
+              type="number"
+              className={fieldClass}
+              min={0}
+              value={params.minDistance}
+              onChange={(e) => setParams({ minDistance: Math.max(0, +e.target.value) })}
+            />
+          </FormField>
+        )}
       </CollapsibleSection>
     </div>
   );

--- a/src/routes/PlanView.tsx
+++ b/src/routes/PlanView.tsx
@@ -77,7 +77,7 @@ export default function PlanView() {
     let pts;
     switch (params.type) {
       case 'grid':
-        pts = generateGrid(effectivePolygon, params.count, params.minDistance);
+        pts = generateGrid(effectivePolygon, params.count);
         break;
       case 'clustered':
         pts = generateClustered(effectivePolygon, params.count, params.minDistance, params.clusterCount ?? 3, params.minClusterDistance ?? 150);
@@ -86,7 +86,7 @@ export default function PlanView() {
         pts = generateW(effectivePolygon, params.count, params.minDistance);
         break;
       case 'ssus':
-        pts = generateSSUS(effectivePolygon, params.count, params.minDistance);
+        pts = generateSSUS(effectivePolygon, params.count);
         break;
       default:
         pts = generateRandom(effectivePolygon, params.count, params.minDistance);


### PR DESCRIPTION
The minimum distance parameter is not meaningful for grid and SSUS sampling
strategies since their point spacing is determined by the grid structure itself.
Applying it was incorrectly preventing placement of valid sample points.

- Remove minDistance parameter from generateGrid and generateSSUS
- Remove satisfiesMinDistance check from SSUS algorithm
- Hide the "Min Distance" field in the UI when grid or SSUS is selected

Fixes #111

https://claude.ai/code/session_01L7LELgFDgPwhASzQ7PxSKZ